### PR TITLE
Allow eloquent scopes to be used in APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,22 @@ For the get command you can filter by using the following url patterns
 You can pass to the filters an array of values
 ie: `filter[user_id]=1||2||||4||7` or `filter[user_id!]=55||33`
 
+## Scopes
+
+In addition to filtering, you can use Laravel's Eloquent [Query Scopes](https://laravel.com/docs/6.x/eloquent#local-scopes) to do more complex searches or filters.
+Simply add an `$allowedScopes` to your `ApiResource`, and that scope will be exposed as a query parameter.
+
+
+Assuming you have a `scopeFullname` defined on your Eloquent Model, you can expose this scope to your API as follows:
+
+```php
+protected static $allowedScopes = [
+  'fullname'
+];
+```
+
+Given the above `$allowedScopes` array, your API consumers will now be able to request `?fullname=John`. The query parameter value will be passed to your scope function in your Eloquent Model.
+
 
 # Fields, Relationships, Sorting & Pagination
 

--- a/src/Contracts/Parser.php
+++ b/src/Contracts/Parser.php
@@ -138,6 +138,21 @@ trait Parser
     }
 
     /**
+     * parses out custom method filters etc.
+     *
+     * @param mixed $request
+     */
+    protected function parseMethodParams($request): void
+    {
+        foreach($this->getAllowedScopes() as $scope)
+        {
+            if($request->has(Helpers::snake($scope))){
+                call_user_func([$this->repository, $scope], $request->get(Helpers::snake($scope)));
+            }
+        }
+    }
+
+    /**
      * set the Where clause.
      *
      * @param array $where the where clause
@@ -169,6 +184,16 @@ trait Parser
     protected function getDefaultFields(): array
     {
         return (method_exists($this->resourceSingle, 'getDefaultFields')) ? ($this->resourceSingle)::getDefaultFields() : ['*'];
+    }
+
+    /**
+     * Gets the allowed scopes for our query.
+     *
+     * @return array
+     */
+    protected function getAllowedScopes(): array
+    {
+        return (method_exists($this->resourceSingle, 'getAllowedScopes')) ? ($this->resourceSingle)::getAllowedScopes() : [];
     }
 
     /**

--- a/src/Contracts/Parser.php
+++ b/src/Contracts/Parser.php
@@ -144,9 +144,8 @@ trait Parser
      */
     protected function parseMethodParams($request): void
     {
-        foreach($this->getAllowedScopes() as $scope)
-        {
-            if($request->has(Helpers::snake($scope))){
+        foreach ($this->getAllowedScopes() as $scope) {
+            if ($request->has(Helpers::snake($scope))) {
                 call_user_func([$this->repository, $scope], $request->get(Helpers::snake($scope)));
             }
         }

--- a/src/Http/Controllers/Api/Controller.php
+++ b/src/Http/Controllers/Api/Controller.php
@@ -108,6 +108,7 @@ abstract class Controller extends BaseController
         $this->parseIncludeParams();
         $this->parseSortParams();
         $this->parseFilterParams();
+        $this->parseMethodParams($request);
         $fields = $this->parseFieldParams();
         $limit = $this->parseLimitParams();
 

--- a/src/Http/Resources/Contracts/AllowableFields.php
+++ b/src/Http/Resources/Contracts/AllowableFields.php
@@ -28,6 +28,13 @@ trait AllowableFields
     protected static $allowedFields = null;
 
     /**
+     * Allowable scopes to be used.
+     *
+     * @var array|null
+     */
+    protected static $allowedScopes = null;
+
+    /**
      * Makes sure we only return allowable fields.
      *
      * @param mixed $request
@@ -116,5 +123,16 @@ trait AllowableFields
     public static function getDefaultFields(): array
     {
         return static::$defaultFields ?? ['*'];
+    }
+
+    /**
+     * Return allowed scopes for this collection.
+     *
+     * @return array
+     * @author Sam Sehnert <sam@customd.com>
+     */
+    public static function getAllowedScopes(): array
+    {
+        return static::$allowedScopes ?? [];
     }
 }


### PR DESCRIPTION
Provides the ability for implementors to easily expose Eloquent Scopes via their API as custom filters.