### PR TITLE
Prevent errors raising exceptions

### DIFF
--- a/src/Http/Controllers/Api/Controller.php
+++ b/src/Http/Controllers/Api/Controller.php
@@ -172,7 +172,7 @@ abstract class Controller extends BaseController
         } catch (\Illuminate\Database\QueryException $exception) {
             $message = config('app.debug') ? $exception->getMessage() : 'Failed to create Record';
 
-            throw new ApiException($message, $exception->getCode(), $exception);
+            throw new ApiException($message, (int)$exception->getCode(), $exception);
         } catch (\Exception $exception) {
             DB::rollback();
 
@@ -266,7 +266,7 @@ abstract class Controller extends BaseController
         } catch (\Illuminate\Database\QueryException $exception) {
             $message = config('app.debug') ? $exception->getMessage() : 'Failed to update Record';
 
-            throw new ApiException($message, $exception->getCode(), $exception);
+            throw new ApiException($message, (int)$exception->getCode(), $exception);
         } catch (\Exception $exception) {
             DB::rollback();
 


### PR DESCRIPTION
Sometimes a `QueryException` is raised where `getCode` returns a non `int` value. This throws an undecipherable error and buries the correct SQL error reporting.

In my case, MySQL was returning `HY000` in the `getCode` result.