### PR TITLE
Resolves an issue with saving related data

### DIFF
--- a/src/Contracts/Relationships.php
+++ b/src/Contracts/Relationships.php
@@ -92,7 +92,7 @@ trait Relationships
                 throw new ApiException("$type mapping not implemented yet");
             }
 
-            $collection = $type === 'HasOne' ? [$data[$with]] : $data[$with];
+            $collection = $type === 'HasOne' ? [$data[Helpers::snake($with)]] : $data[Helpers::snake($with)];
             $this->repository->with($with);
             $localKey = $relation->getLocalKeyName();
 


### PR DESCRIPTION
When relationships are defined on models with camel case, the request input gets converted to snake case, so `$data` contains the related data in snake case key.

This converts the snake case key so that we can find the data to save, avoiding an undefined index error.