### PR TITLE
Query sub-modules

### DIFF
--- a/src/Contracts/Parser.php
+++ b/src/Contracts/Parser.php
@@ -62,7 +62,7 @@ trait Parser
             $sub = self::$model->{$with}()->getRelated();
             $fields = $this->getIncludesFields($with);
             $where = array_filter(self::$uriParser->whereParameters(), function ($where) use ($with) {
-                return strpos($where['key'], $with . '.') !== false;
+                return strpos($where['key'], $with.'.') !== false;
             });
 
             if (! empty($fields)) {
@@ -71,13 +71,13 @@ trait Parser
 
             if (! empty($where)) {
                 $where = array_map(function ($whr) use ($with) {
-                    $whr['key'] = str_replace($with . '.', '', $whr['key']);
+                    $whr['key'] = str_replace($with.'.', '', $whr['key']);
+
                     return $whr;
                 }, $where);
             }
 
             $withs[$with] = function ($query) use ($fields, $where) {
-
                 if (! empty($fields)) {
                     $query->select(implode(',', array_unique($fields)));
                 }

--- a/src/Repository/BaseRepository.php
+++ b/src/Repository/BaseRepository.php
@@ -427,8 +427,12 @@ class BaseRepository
      */
     protected function eagerLoad()
     {
-        foreach ($this->with as $relation) {
-            $this->query->with($relation);
+        foreach ($this->with as $key => $relation) {
+            if (is_numeric($key)) {
+                $this->query->with($relation);
+            } else {
+                $this->query->with([$key => $relation]);
+            }
         }
 
         return $this;

--- a/src/Repository/BaseRepository.php
+++ b/src/Repository/BaseRepository.php
@@ -2,10 +2,11 @@
 
 namespace Phpsa\LaravelApiController\Repository;
 
-use Illuminate\Database\Eloquent\Collection;
+use Closure;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Eloquent\Collection;
 use Phpsa\LaravelApiController\Exceptions\ApiException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 /**
  * Class BaseRepository.
@@ -349,12 +350,13 @@ class BaseRepository
      *
      * @return $this
      */
-    public function where($column, $value, $operator = '=')
+    public function where(string $column, ?string $operator = null, ?string $value = null)
     {
-        $this->wheres[] = compact('column', 'value', 'operator');
+        $this->wheres[] = func_get_args();//compact('column', 'operator', 'value');
 
         return $this;
     }
+
 
     /**
      * Add a simple where in clause to the query.
@@ -446,7 +448,7 @@ class BaseRepository
     protected function setClauses()
     {
         foreach ($this->wheres as $where) {
-            $this->query->where($where['column'], $where['operator'], $where['value']);
+            $this->query->where(...$where);
         }
 
         foreach ($this->whereIns as $whereIn) {

--- a/src/Repository/BaseRepository.php
+++ b/src/Repository/BaseRepository.php
@@ -405,7 +405,7 @@ class BaseRepository
             $relations = func_get_args();
         }
 
-        $this->with = array_unique(array_merge($this->with, $relations));
+        $this->with = array_merge($this->with, $relations);
 
         return $this;
     }


### PR DESCRIPTION
Updates the sub-query to use the filters for your request

Ie: running a query with an include=subTable&filter[subtable.field]=xxxx in current code will run the filter, however will return subTable results that are not matching aswell in the result set,

this patch allows us to now append the filters to that query and return only the matched records back with the result.