### PR TITLE
Updates table column fetching

### DIFF
--- a/src/Contracts/Relationships.php
+++ b/src/Contracts/Relationships.php
@@ -87,11 +87,6 @@ trait Relationships
         foreach ($filteredRelateds as $with) {
             $relation = $item->$with();
             $type = class_basename(get_class($relation));
-
-            if (! in_array($type, ['HasOne', 'HasMany', 'BelongsTo', 'MorphOne', 'MorphMany', 'MorphTo', 'MorphToMany', 'BelongsToMany'])) {
-                throw new ApiException("$type mapping not implemented yet");
-            }
-
             $relatedRecords = $data[Helpers::snake($with)];
 
             $this->repository->with($with);
@@ -113,17 +108,11 @@ trait Relationships
                 case 'MorphToMany':
                     $this->processBelongsToManyRelation($relation, $relatedRecords, $item, $data, $with);
                     break;
+                default:
+                    throw new ApiException("$type mapping not implemented yet");
+                    break;
             }
         }
-    }
-
-    protected function storeRelatedChild($relatedItem, $data): void
-    {
-        //$columns = $this->getTableColumns($relatedItem);
-        //$insert = array_intersect_key($data, array_flip($columns));
-        //$diff = array_diff(array_keys($data), array_keys($insert));
-        // then similar to the main methodology
-        //@todo
     }
 
     protected function processHasOneRelation($relation, array $collection, $item): void

--- a/src/Http/Api/Contracts/HasModel.php
+++ b/src/Http/Api/Contracts/HasModel.php
@@ -97,7 +97,8 @@ trait HasModel
         if (is_null($model)) {
             $model = self::$model;
         }
-        $table = explode('.',$model->getTable());
+        $table = explode('.', $model->getTable());
+
         return end($table);
     }
 

--- a/src/Http/Api/Contracts/HasModel.php
+++ b/src/Http/Api/Contracts/HasModel.php
@@ -88,6 +88,20 @@ trait HasModel
     }
 
     /**
+     * Gets the table name without database identifier.
+     *
+     * @param Model $model
+     */
+    protected function getUnqualifiedTableName(?Model $model = null): string
+    {
+        if (is_null($model)) {
+            $model = self::$model;
+        }
+        $table = explode('.',$model->getTable());
+        return end($table);
+    }
+
+    /**
      * Set which columns area available in the model.
      *
      * @param Model $model
@@ -97,7 +111,7 @@ trait HasModel
         if (is_null($model)) {
             $model = self::$model;
         }
-        $table = $model->getTable();
+        $table = $this->getUnqualifiedTableName($model);
         $this->tableColumns[$table] = Schema::connection($model->getConnectionName())->getColumnListing($table);
     }
 
@@ -114,7 +128,7 @@ trait HasModel
             $model = self::$model;
         }
 
-        $table = $model->getTable();
+        $table = $this->getUnqualifiedTableName($model);
 
         if (! isset($this->tableColumns[$table])) {
             $this->setTableColumns($model);

--- a/src/Http/Api/Contracts/HasResources.php
+++ b/src/Http/Api/Contracts/HasResources.php
@@ -89,7 +89,7 @@ trait HasResources
     }
 
     /**
-     * Parse the value to string / array based in input
+     * Parse the value to string / array based in input.
      *
      * @param string|array|null $value
      *
@@ -97,9 +97,10 @@ trait HasResources
      */
     protected function parseScopeValue($value = null)
     {
-        if($value === null || is_array($value) || strpos($value, '||') === false){
+        if ($value === null || is_array($value) || strpos($value, '||') === false) {
             return $value;
         }
-        return explode("||", $value);
+
+        return explode('||', $value);
     }
 }


### PR DESCRIPTION
+ Prevents errors if people are using fully qualified table names in cross-database situations

To test, use a multi-database setup. These databases should be on the same DB server. Create a second connection for your database, and use a trait which overwrites the models `getTable()` method. Something like:

```php
<?php

namespace App\Models\Traits;

trait DefaultConnection
{
    public function getConnectionName()
    {
        return config('database.default');
    }

    public function getTable()
    {
        $dbName = $this->getConnection()->getDatabaseName();
        $table = parent::getTable();
        return $dbName === ':memory:' ? $table : $dbName . "." . $table;
    }
}
```

Once all that is done, create a model using this trait, and an API controller for that model. I found this issue when using a `handleIndexActionRaw` call, but it's likely to happen with all calls.

Ensure that after this patch, requests work as expected.

*NOTE* This patch also works if someone sets the database name directly into the table name on the model, E.g., 

```php
<?php

namespace App\Models;

use Illuminate\Database\Eloquent\Model;

class Thing extends Model
{
    protected $table = 'default.things';
}
```