### PR TITLE
Parse sync fields

### DIFF
--- a/src/Contracts/Parser.php
+++ b/src/Contracts/Parser.php
@@ -147,11 +147,10 @@ trait Parser
 
             $withTable = $relation->getRelated()->getTable();
 
-            $withTableName = strpos($withTable, ".") === false ? $withConnection . '.' . $withTable : $withTable;
+            $withTableName = strpos($withTable, '.') === false ? $withConnection.'.'.$withTable : $withTable;
 
             $this->repository->join($withTableName, "{$withTableName}.{$foreignKey}", "{$currentTable}.{$localKey}");
             $this->repository->orderBy("{$withTableName}.{$key}", $sortD);
-
         }
     }
 

--- a/src/Contracts/Relationships.php
+++ b/src/Contracts/Relationships.php
@@ -183,14 +183,13 @@ trait Relationships
         $relatedKey = $relation->getRelatedKeyName();
 
         $model = $relation->getRelated();
-        $pivots =  $relation->getPivotColumns();
+        $pivots = $relation->getPivotColumns();
 
         $syncWithRelated = Helpers::snakeCaseArrayKeys(request()->get('sync') ?? []);
         $detach = filter_var($syncWithRelated[Helpers::snake($with)] ?? false, FILTER_VALIDATE_BOOLEAN);
         $sync = collect();
 
         foreach ($relatedRecords as $relatedRecord) {
-
             if (! isset($relatedRecord[$parentKey])) {
                 $relatedRecord[$parentKey] = $item->getAttribute($relatedKey);
             }
@@ -205,17 +204,14 @@ trait Relationships
             }
 
             $pvals = [];
-            if($pivots){
-
-                foreach($pivots as $pivot)
-                {
-                    if(isset($relatedRecord[$pivot])){
+            if ($pivots) {
+                foreach ($pivots as $pivot) {
+                    if (isset($relatedRecord[$pivot])) {
                         $pvals[$pivot] = $relatedRecord[$pivot];
                     }
                 }
             }
             $sync->put($record->getKey(), $pvals);
-
         }
 
         $relation->sync($sync->toArray(), $detach);

--- a/src/Contracts/Relationships.php
+++ b/src/Contracts/Relationships.php
@@ -183,10 +183,11 @@ trait Relationships
         $relatedKey = $relation->getRelatedKeyName();
 
         $model = $relation->getRelated();
-        $sync = collect();
-
         $pivots =  $relation->getPivotColumns();
-        $detach = filter_var(request()->get('sync')[$with] ?? false, FILTER_VALIDATE_BOOLEAN);
+
+        $syncWithRelated = Helpers::snakeCaseArrayKeys(request()->get('sync') ?? []);
+        $detach = filter_var($syncWithRelated[Helpers::snake($with)] ?? false, FILTER_VALIDATE_BOOLEAN);
+        $sync = collect();
 
         foreach ($relatedRecords as $relatedRecord) {
 

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -162,9 +162,10 @@ class Helpers
     protected static function fieldsFromPutPost($request, $fields): array
     {
         $method = $request->method();
-        if (! in_array($method, ['PUT','POST','PATCH'])) {
+        if (! in_array($method, ['PUT', 'POST', 'PATCH'])) {
             return [];
         }
+
         return array_values(collect($request->all())->filter(function ($item, $key) use ($fields) {
             if (in_array($key, $fields)) {
                 return false;
@@ -172,7 +173,8 @@ class Helpers
             if (! is_array($item) && ! is_object($key)) {
                 return false;
             }
-                return true;
+
+            return true;
         })->map(function ($item, $key) {
             return $key;
         })->toArray());

--- a/src/Http/Api/Contracts/HasResponse.php
+++ b/src/Http/Api/Contracts/HasResponse.php
@@ -243,7 +243,6 @@ trait HasResponse
         throw new HttpException(501, $message);
     }
 
-
     protected function handleIndexResponse($items)
     {
         return $this->respondWithMany($items);


### PR DESCRIPTION
+ Properly use case mapping on sync related fields.

Previously, flags like `?sync[practice_areas]=true` would not result in the `practiceAreas` relationship being synced. After this patch, input with either snake or camel keys will work.