### PR TITLE
Feature/gated fields

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,8 @@ notifications:
     on_failure: always
 
 php:
-  - 7.3
-  - 7.4
   - 8.0
+  - 8.1
 
 env:
   - LARAVEL_VERSION=6.*

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     }
   ],
   "require": {
-    "php": "^7.3|^8.0",
+    "php": "^8.0",
     "laravel/framework": "^6.0|^7.30.3|^8.0"
   },
   "require-dev": {

--- a/src/Http/Api/Contracts/HasModel.php
+++ b/src/Http/Api/Contracts/HasModel.php
@@ -39,7 +39,11 @@ trait HasModel
      *
      * @return string (model classname)
      */
-    abstract protected function model();
+    protected function model()
+    {
+        throw_if(! property_exists($this, 'resourceModel'), RuntimeException::class, 'Api Controller requires the model to be listed on the resourceModel property of your Controller');
+        return $this->resourceModel;
+    }
 
     /**
      * @throws ApiException

--- a/src/Http/Api/Contracts/HasModel.php
+++ b/src/Http/Api/Contracts/HasModel.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 use Phpsa\LaravelApiController\Helpers;
 use Phpsa\LaravelApiController\Exceptions\ApiException;
 use Phpsa\LaravelApiController\Http\Api\Contracts\HasQueryBuilder;
+use RuntimeException;
 
 trait HasModel
 {

--- a/src/Http/Api/Controller.php
+++ b/src/Http/Api/Controller.php
@@ -182,7 +182,8 @@ abstract class Controller extends BaseController
         $this->qualifyItemQuery();
 
         try {
-            $item = $this->builder->findOrFail($id, $fields);
+            $item = $this->builder->whereKey($id)->firstOrFail($fields);
+
             $this->authoriseUserAction('view', $item);
         } catch (ModelNotFoundException $exception) {
             return $this->errorNotFound('Record not found');
@@ -206,7 +207,7 @@ abstract class Controller extends BaseController
         $this->handleCommonActions($request);
 
         try {
-            $item = $this->builder->findOrFail($id);
+            $item = $this->builder->whereKey($id)->firstOrFail();
             $this->authoriseUserAction('update', $item);
         } catch (ModelNotFoundException $exception) {
             return $this->errorNotFound('Record does not exist');
@@ -256,7 +257,7 @@ abstract class Controller extends BaseController
         $this->qualifyItemQuery();
 
         try {
-            $item = $this->builder->findOrFail($id);
+            $item = $this->builder->whereKey($id)->firstOrFail();
             $this->authoriseUserAction('delete', $item);
             $item->delete();
         } catch (ModelNotFoundException $exception) {

--- a/src/Http/Api/Controller.php
+++ b/src/Http/Api/Controller.php
@@ -169,7 +169,7 @@ abstract class Controller extends BaseController
      * Display the specified resource.
      * GET /api/{resource}/{id}.
      *
-     * @param int                                                              $id
+     * @param \Illuminate\Database\Eloquent\Model|int|string $id Model id / model instance for the record
      * @param \Illuminate\Http\Request|\Illuminate\Foundation\Http\FormRequest|null $request
      */
     public function handleShowAction($id, $request = null, array $extraParams = [])
@@ -196,7 +196,7 @@ abstract class Controller extends BaseController
      * Update the specified resource in storage.
      * PUT /api/{resource}/{id}.
      *
-     * @param int                                                              $id
+     * @param \Illuminate\Database\Eloquent\Model|int|string $id Model id / model instance for the record                                                            $id
      * @param \Illuminate\Http\Request|\Illuminate\Foundation\Http\FormRequest $request
      */
     public function handleUpdateAction($id, $request, array $extraParams = [])
@@ -248,7 +248,7 @@ abstract class Controller extends BaseController
      * Remove the specified resource from storage.
      * DELETE /api/{resource}/{id}.
      *
-     * @param int                                                              $id
+     * @param \Illuminate\Database\Eloquent\Model|int|string $id Model id / model instance for the record                                                             $id
      * @param \Illuminate\Http\Request|\Illuminate\Foundation\Http\FormRequest|null $request
      */
     public function handleDestroyAction($id, $request = null)


### PR DESCRIPTION
Updates to the release of the V3 Branch

[ ] php8 and up only
[ ] ability to use `protected $resourceModel = xxx::class` instead of `public function model() { return xxx::class }` - will make static analysis better long term
[ ] ability to use route model binding on the controller endpoints 
[ ] Filtering of fields via gates

Example implementations
```php
//Controller
protected $resourceModel = MyClass::class;
protected $resourceSingle = MyClassResource::class;
...
// this used to require the ID and casts where INT based. (some keys may be string based)
// passing the route param is also better long term as is more laravelEsq
public function show(MyClass $record) {
    return $this->handleShowAction($record);
}

//MyClassResource

protected static array $fieldGates = [
    'gate_name' => [
        'field 1',
        'field 2',
     ],
     'gate_two' => [
       'field 3,
     ]
];

```