### PR TITLE
Nested api controller for fetching child resources

### DIFF
--- a/src/Generator/stubs/controller.nested.api.stub
+++ b/src/Generator/stubs/controller.nested.api.stub
@@ -3,12 +3,19 @@
 namespace {{ namespace }};
 
 use {{ namespacedModel }};
-use {{ rootNamespace }}Http\Controllers\Controller;
-use Illuminate\Http\Request;
+use Phpsa\LaravelApiController\Http\Api\Controller;
+use {{ namespacedRequests }}
+use {{ useResourceSingle }};
+use {{ useResourceCollection }};
 use {{ namespacedParentModel }};
 
 class {{ class }} extends Controller
 {
+
+    protected string $resourceModel = {{ model }}::class;
+    protected $resourceSingle = {{ resourceSingle }}::class;
+    protected $resourceCollection = {{ resourceCollection }}::class;
+    protected string $parentModel = Viewing::class;
     /**
      * Display a listing of the resource.
      *
@@ -17,19 +24,19 @@ class {{ class }} extends Controller
      */
     public function index({{ parentModel }} ${{ parentModelVariable }})
     {
-        //
+        return $this->handleIndexAction();
     }
 
     /**
      * Store a newly created resource in storage.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \{{ namespacedStoreRequest }}  $request
      * @param  \{{ namespacedParentModel }}  ${{ parentModelVariable }}
      * @return \Illuminate\Http\Response
      */
-    public function store(Request $request, {{ parentModel }} ${{ parentModelVariable }})
+    public function store({{ storeRequest }} $request, {{ parentModel }} ${{ parentModelVariable }})
     {
-        //
+        return $this->handleStoreAction($request);
     }
 
     /**
@@ -41,20 +48,20 @@ class {{ class }} extends Controller
      */
     public function show({{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }})
     {
-        //
+        return $this->handleShowAction(${{ modelVariable }});
     }
 
     /**
      * Update the specified resource in storage.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \{{ namespacedUpdateRequest }}  $request
      * @param  \{{ namespacedParentModel }}  ${{ parentModelVariable }}
      * @param  \{{ namespacedModel }}  ${{ modelVariable }}
      * @return \Illuminate\Http\Response
      */
-    public function update(Request $request, {{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }})
+    public function update({{ updateRequest }} $request, {{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }})
     {
-        //
+        return $this->handleUpdateAction(${{ modelVariable }}, $request);
     }
 
     /**
@@ -66,6 +73,6 @@ class {{ class }} extends Controller
      */
     public function destroy({{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }})
     {
-        //
+        return $this->handleDestroyAction(${{ modelVariable }});
     }
 }

--- a/src/Http/Api/Contracts/HasParser.php
+++ b/src/Http/Api/Contracts/HasParser.php
@@ -71,7 +71,7 @@ trait HasParser
 
         $this->authoriseUserAction('view', $routeRelation);
 
-        if($this->request->isMethod('get'))
+        if($this->request->isMethod('get') || $this->request->isMethod('options'))
         {
             return [
                 'filter' => [

--- a/src/Http/Api/Contracts/HasParser.php
+++ b/src/Http/Api/Contracts/HasParser.php
@@ -58,6 +58,8 @@ trait HasParser
             $key = strtolower(class_basename($parent));
         }
 
+        $this->authoriseUserAction("access" . ucFirst($key), self::$model, true);
+
         if($this->request->isMethod('get'))
         {
             return [

--- a/src/Http/Api/Contracts/HasParser.php
+++ b/src/Http/Api/Contracts/HasParser.php
@@ -56,14 +56,15 @@ trait HasParser
             $param = reset($parent);
         }else{
             $key = strtolower(class_basename($parent));
+            $param = $key;
         }
 
-        $routeRelation = $this->request->route()->parameter($key);
+        $routeRelation = $this->request->route()->parameter($param);
 
         $child = resolve($this->model());
 
         if(!$routeRelation instanceof Model){
-            $bindingField = $this->request->route()->bindingFieldFor($key) ?? $child->{$key}()->getRelated()->getKeyName();
+            $bindingField = $this->request->route()->bindingFieldFor($param) ?? $child->{$key}()->getRelated()->getKeyName();
             $routeRelation = $child->{$key}()->getRelated()->where($bindingField, $routeRelation)->firstOrFail();
         }
 

--- a/src/Http/Api/Contracts/HasParser.php
+++ b/src/Http/Api/Contracts/HasParser.php
@@ -80,12 +80,14 @@ trait HasParser
             ];
         }
 
-        if($this->request->isMethod('post'))
+        if($this->request->isMethod('post') || $this->request->isMethod('put') || $this->request->isMethod('patch'))
         {
             return [
                 $child->{$key}()->getForeignKeyName() => $routeRelation->getKey()
             ];
         }
+            
+            return [];
 
     }
 

--- a/src/Http/Api/Contracts/HasParser.php
+++ b/src/Http/Api/Contracts/HasParser.php
@@ -3,6 +3,7 @@
 namespace Phpsa\LaravelApiController\Http\Api\Contracts;
 
 use Illuminate\Support\Collection;
+use Illuminate\Database\Eloquent\Model;
 use Phpsa\LaravelApiController\Helpers;
 use Phpsa\LaravelApiController\UriParser;
 

--- a/src/Http/Api/Contracts/HasPolicies.php
+++ b/src/Http/Api/Contracts/HasPolicies.php
@@ -81,9 +81,9 @@ trait HasPolicies
      *
      * @return bool
      */
-    protected function authoriseUserAction(string $ability, $arguments = null): bool
+    protected function authoriseUserAction(string $ability, $arguments = null, bool $excludeMissing = false): bool
     {
-        if (! $this->testUserPolicyAction($ability, $arguments)) {
+        if (! $this->testUserPolicyAction($ability, $arguments, $excludeMissing)) {
             /** @scrutinizer ignore-call */
             $this->errorUnauthorized();
         }
@@ -101,7 +101,7 @@ trait HasPolicies
      *
      * @return bool
      */
-    protected function testUserPolicyAction(string $ability, $arguments = null): bool
+    protected function testUserPolicyAction(string $ability, $arguments = null, bool $excludeMissing): bool
     {
         // If no arguments are specified, set it to the controller's model (default)
         if ($arguments === null) {
@@ -117,7 +117,7 @@ trait HasPolicies
 
         $modelPolicy = Gate::getPolicyFor($model);
         // If no policy exists for this model, then there's nothing to check
-        if (is_null($modelPolicy)) {
+        if (is_null($modelPolicy) || ($excludeMissing && !method_exists($modelPolicy, $ability)) ) {
             return true;
         }
 


### PR DESCRIPTION
This method allows us to create a nested child API controller route

* [ ] artisan make:api:controller ChildController --parent=Parent
* [ ] Confirm both the following methods work for relations in the ChildController
  - `protected string $parentModel = Viewing::class;`. -- this is where the relation and the url key will be the strtolower of the base classname, ie `/api/viewing/{viewing}/notes` and in the Notes model the method to get the related record is named `viewing`
    - should either of the 2 names in the first method be different, then an array can be passed:
    ` ['relationnameInModel' => 'routeParamName']`
  * [ ] confirm index method gets only the records related to the specific parent
  * [ ] confirm create method auto-adds the id to the created record
  * [ ] Show / Update/ Delete should validate based on parent / child