### PR TITLE
fix/deprecation-warning-if-case-header-not-supplied

### DIFF
--- a/src/Http/Resources/Contracts/CaseFormat.php
+++ b/src/Http/Resources/Contracts/CaseFormat.php
@@ -8,7 +8,7 @@ trait CaseFormat
 {
     protected function caseFormat($request, $data)
     {
-        switch (strtolower($request->header('X-Accept-Case-Type'))) {
+        switch (strtolower((string)$request->header('X-Accept-Case-Type'))) {
             case 'camel':
             case 'camel-case':
                 return Helpers::camelCaseArrayKeys($data);


### PR DESCRIPTION
`strtolower()` requires a string, so we'll force it.

Could do a fetch, type check, and early return... but this is cleaner.