### PR TITLE
fixes issue where resourceModel is empty

### DIFF
--- a/src/Http/Api/Contracts/HasModel.php
+++ b/src/Http/Api/Contracts/HasModel.php
@@ -48,7 +48,7 @@ trait HasModel
      */
     protected function model()
     {
-        throw_if(! property_exists($this, 'resourceModel'), RuntimeException::class, 'Api Controller requires the model to be listed on the resourceModel property of your Controller');
+        throw_if(! property_exists($this, 'resourceModel') || empty($this->resourceModel), RuntimeException::class, 'Api Controller requires the model to be listed on the resourceModel property of your Controller');
         return $this->resourceModel;
     }
 


### PR DESCRIPTION
if resourceModel is not changed from the empty / null state, an error occurs :`Error: Typed property Phpsa\LaravelApiController\Http\Api\Controller::$resourceModel must not be accessed before initialization in  ... `


this fixes it