### PR TITLE
feat: allowing cached table columns to optimize performances

### DIFF
--- a/config/laravel-api-controller.php
+++ b/config/laravel-api-controller.php
@@ -12,6 +12,10 @@ return [
     // Relative path from the base directory to the route stub.
     'route_stub' => env('PHPSA_API_ROUTE_STUB', 'vendor/phpsa/laravel-api-controller/src/Generator/stubs/route.stub'),
 
+    'cache_table_columns' => env('PHPSA_API_CACHE_TABLE_COLUMNS', false), // Cache table columns
+    'cache_table_columns_ttl' => env('PHPSA_API_CACHE_TABLE_COLUMNS_TTL', 60 * 60 * 24), // Cache table columns ttl
+    'cache_table_columns_prefix' => env('PHPSA_API_CACHE_TABLE_COLUMNS_PREFIX', 'phpsa_table_columns_'), // Cache table columns prefix
+
     'parameters' => [
         'include' => 'include', // which hasOnes / HasMany etc to include in the response
         'filter' => 'filter', // filter on fields


### PR DESCRIPTION
In our company we use the library, yet every time an API is called, a useless call is made to our database, effectively slowing it down in high-volume scenarios.

This PR introduces 3 new config options which can be set to cache the columns extracted from DB.

It is an opt-in improvement, so nothing will break if merged.