### PR TITLE
feat: add support to custom guard in controller and resource

### DIFF
--- a/src/Http/Api/Contracts/HasParser.php
+++ b/src/Http/Api/Contracts/HasParser.php
@@ -86,7 +86,8 @@ trait HasParser
         $parentPolicy = Gate::getPolicyFor($routeRelation);
 
         if (! is_null($parentPolicy)) {
-            $this->authorize('view', $routeRelation);
+            $user = auth($this->guard)->user();
+            $this->authorizeForUser($user, 'view', $routeRelation);
         }
 
         $filter = match (class_basename(get_class($relation))) {

--- a/src/Http/Api/Contracts/HasPolicies.php
+++ b/src/Http/Api/Contracts/HasPolicies.php
@@ -13,7 +13,7 @@ trait HasPolicies
      */
     protected function qualifyCollectionQuery(): void
     {
-        $user = auth()->user();
+        $user = auth($this->guard)->user();
         $modelPolicy = Gate::getPolicyFor($this->model());
 
         if ($modelPolicy && method_exists($modelPolicy, 'qualifyCollectionQueryWithUser')) {
@@ -28,7 +28,7 @@ trait HasPolicies
      */
     protected function qualifyItemQuery(): void
     {
-        $user = auth()->user();
+        $user = auth($this->guard)->user();
         $modelPolicy = Gate::getPolicyFor($this->model());
 
         if ($modelPolicy && method_exists($modelPolicy, 'qualifyItemQueryWithUser')) {
@@ -45,7 +45,7 @@ trait HasPolicies
      */
     protected function qualifyStoreQuery(array $data): array
     {
-        $user = auth()->user();
+        $user = auth($this->guard)->user();
         $modelPolicy = Gate::getPolicyFor($this->model());
 
         if ($modelPolicy && method_exists($modelPolicy, 'qualifyStoreDataWithUser')) {
@@ -64,7 +64,7 @@ trait HasPolicies
      */
     protected function qualifyUpdateQuery(array $data): array
     {
-        $user = auth()->user();
+        $user = auth($this->guard)->user();
         $modelPolicy = Gate::getPolicyFor($this->model());
 
         if ($modelPolicy && method_exists($modelPolicy, 'qualifyUpdateDataWithUser')) {
@@ -124,8 +124,10 @@ trait HasPolicies
             return true;
         }
 
+        $user = auth($this->guard)->user();
+
         /* @scrutinizer ignore-call */
-        $this->authorize($ability, $model);
+        $this->authorizeForUser($user, $ability, $model);
 
         return true;
     }

--- a/src/Http/Api/Contracts/HasResponse.php
+++ b/src/Http/Api/Contracts/HasResponse.php
@@ -58,6 +58,7 @@ trait HasResponse
     protected function respondWithResource($resource, $data, $code = null, $headers = [])
     {
         return $resource::make($data)
+            ->setGuard($this->guard)
             ->response()
             ->setStatusCode($code ?? $this->getStatusCode())
             ->withHeaders($headers);

--- a/src/Http/Api/Controller.php
+++ b/src/Http/Api/Controller.php
@@ -63,6 +63,14 @@ abstract class Controller extends BaseController
     protected $maximumLimit = 0;
 
     /**
+     * Guard to use for authentication and authorization.
+     * null defaults to default guard config (auth.defaults.guard)
+     *
+     * @var ?string
+     */
+    protected $guard = null;
+
+    /**
      * Display a listing of the resource.
      * GET /api/{resource}.
      *

--- a/src/Http/Resources/ApiCollection.php
+++ b/src/Http/Resources/ApiCollection.php
@@ -17,7 +17,7 @@ class ApiCollection extends ResourceCollection
      */
     protected ?string $guard = null;
 
-    public function setGuard(string $guard): static
+    public function setGuard(?string $guard): static
     {
         $this->guard = $guard;
 

--- a/src/Http/Resources/ApiCollection.php
+++ b/src/Http/Resources/ApiCollection.php
@@ -9,6 +9,21 @@ use Illuminate\Http\Request;
 class ApiCollection extends ResourceCollection
 {
 
+    /**
+     * Guard used to retrieve the user from the request.
+     * null defaults to default guard config (auth.defaults.guard)
+     *
+     * @var ?string
+     */
+    protected ?string $guard = null;
+
+    public function setGuard(string $guard): static
+    {
+        $this->guard = $guard;
+
+        return $this;
+    }
+
     protected ?string $fieldKey = null;
 
     protected function collects()
@@ -31,7 +46,7 @@ class ApiCollection extends ResourceCollection
     public function toArray(Request $request)
     {
         return $this->collection->map(
-            fn($item) => $item->setFieldKey($this->fieldKey)->toArray($request)
+            fn($item) => $item->setGuard($this->guard)->setFieldKey($this->fieldKey)->toArray($request)
         )->all();
     }
 }

--- a/src/Http/Resources/Contracts/AllowableFields.php
+++ b/src/Http/Resources/Contracts/AllowableFields.php
@@ -149,7 +149,7 @@ trait AllowableFields
         return $this->filterAllowedFields($fields);
     }
 
-    public function setGuard(string $guard): static
+    public function setGuard(?string $guard): static
     {
         $this->guard = $guard;
 

--- a/src/Http/Resources/Contracts/AllowableFields.php
+++ b/src/Http/Resources/Contracts/AllowableFields.php
@@ -54,6 +54,14 @@ trait AllowableFields
     protected static ?array $fieldGates = null;
 
     /**
+     * Guard used to retrieve the user from the request.
+     * null defaults to default guard config (auth.defaults.guard)
+     *
+     * @var ?string
+     */
+    protected ?string $guard = null;
+
+    /**
      * Makes sure we only return allowable fields.
      *
      * @param mixed $request
@@ -141,6 +149,13 @@ trait AllowableFields
         return $this->filterAllowedFields($fields);
     }
 
+    public function setGuard(string $guard): static
+    {
+        $this->guard = $guard;
+
+        return $this;
+    }
+
     public function filterAllowedFields($fields)
     {
         if (empty(static::$allowedFields) || static::$allowedFields === ['*']) {
@@ -217,7 +232,7 @@ trait AllowableFields
         return collect($this->mapFields($request))
         ->when(
             ! empty(static::$fieldGates),
-            fn($collection) => $collection->filter(fn($field) => $this->filterUserField($field, $request->user()))
+            fn($collection) => $collection->filter(fn($field) => $this->filterUserField($field, $request->user($this->guard)))
         )
         ->toArray();
     }


### PR DESCRIPTION
In our company we are using PHPSA Controllers with a custom guard different from the default one.
This PR adds the ability to specify a custom guard to be used within a controller and in the resources created from it.